### PR TITLE
Symfony 4 compatibility, make services public

### DIFF
--- a/Resources/config/services/services.xml
+++ b/Resources/config/services/services.xml
@@ -15,11 +15,11 @@
     </parameters>
 
     <services>
-        <service id="secotrust.sabredav.controller" class="%secotrust.sabredav.controller.class%">
+        <service id="secotrust.sabredav.controller" class="%secotrust.sabredav.controller.class%" public="true">
             <argument type="service" id="secotrust.sabredav.server" />
             <argument type="service" id="router" />
         </service>
-        <service id="secotrust.sabredav.server" class="%secotrust.sabredav.server.class%">
+        <service id="secotrust.sabredav.server" class="%secotrust.sabredav.server.class%" public="true">
             <argument id="secotrust.sabredav.server.nodes" />
         </service>
     </services>


### PR DESCRIPTION
We need to make both these services public to avoid incompatibility with Symfony 4. 

Don't think there is even a way to use the services of another bundle unless they are public. So DI is not an option here.